### PR TITLE
Warn rather than raise if file not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: elixir
+elixir:
+  - 1.3
 otp_release:
-  - 17.4
+  - 19.0

--- a/lib/figaro_elixir/yaml.ex
+++ b/lib/figaro_elixir/yaml.ex
@@ -1,11 +1,16 @@
 defmodule FigaroElixir.Yaml do
+  require Logger
+
   @config_path "config/application.yml"
 
   def load_file(path \\ @config_path) do
     file = config_file(path)
     cond do
-      File.exists?(file) -> parse_file(file)
-      true               -> raise "#{file} file not found"
+      File.exists?(file) ->
+        parse_file(file)
+      true ->
+        Logger.warn "#{path} file not found"
+        %{}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule FigaroElixir.Mixfile do
     [
       app:             :figaro_elixir,
       version:         "1.0.0",
-      elixir:          "~> 1.0",
+      elixir:          "~> 1.3",
       build_embedded:  Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       description:     description,

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"yamerl": {:git, "git://github.com/yakaz/yamerl.git", "ae810a808817d9482b4628ae3e20d746e3729fe0", []}}
+%{"yamerl": {:git, "https://github.com/yakaz/yamerl.git", "3f46bf06b9aa7c17ea6038dc8cf1ae078fc0c497", []}}

--- a/test/figaro_elixir/yaml_test.exs
+++ b/test/figaro_elixir/yaml_test.exs
@@ -1,6 +1,8 @@
 defmodule FigaroElixir.YamlTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   alias FigaroElixir.Yaml
 
   test "parsing flat file contents" do
@@ -29,12 +31,8 @@ defmodule FigaroElixir.YamlTest do
   end
 
   test "file not found" do
-    assert_raise(
-      RuntimeError,
-      fn ->
-        Yaml.load_file("test.yml")
-      end
-    )
+    assert capture_log(fn -> Yaml.load_file("missing.yml") end) =~ "missing.yml file not found"
+    assert_result "missing", %{}
   end
 
   defp assert_result(file_name, expectation) do


### PR DESCRIPTION
# Challenge

We're using `figaro-elixir` in a project, and we have run into a problem integrating it with CI. We don't want to check the `application.yml` into the repo, but our CI server needs access to env vars to run. Currently, when there is no `application.yml` accessible, it throws an exception on startup. We can work around this with git hacks, but that's not a particularly clean solution.
# Proposed Solution

This proposed change warns that the file could not be found, and continues on as if there were an empty file. This allows us to set our CI variables directly in the environment, and use `System.get_env` to access our variables in all environments.

I hope that this is helpful 😄
